### PR TITLE
Fix FlareMap Parsing

### DIFF
--- a/code/flare_map/FlareMap.h
+++ b/code/flare_map/FlareMap.h
@@ -13,18 +13,18 @@ class FlareMap {
 	public:
 		FlareMap();
 		~FlareMap();
-	
-		void Load(const std::string fileName);
+
+		void Load(const std::string &fileName);
 
 		int mapWidth;
 		int mapHeight;
-		unsigned int **mapData;
+		int **mapData;
 		std::vector<FlareMapEntity> entities;
-	
+
 	private:
-	
+
 		bool ReadHeader(std::ifstream &stream);
 		bool ReadLayerData(std::ifstream &stream);
 		bool ReadEntityData(std::ifstream &stream);
-	
+
 };


### PR DESCRIPTION
Several things are fixed:

1. use int instead of unsigned int to deal with empty tile (originally the empty tile is 0, which is the same index as the first tile in the sprite sheet; after changing the FlareMap, the empty tile is -1, which can easily reduced when rendering);

2. passing string as constant reference to remove unnecessary copy;

3. parsing the txt file is fixed by a simple approach: comparing both with ```"[header]"``` and ```"[header]\r"```; detailed discussion is below:

someone with windows cannot use the FlareMap properly, because in windows the end-of-line character is translating ```\r\n``` into ```\n``` (as discussed in https://stackoverflow.com/a/23791122/8127729), so the windows version of txt file is ending with ```\r\n``` in reality, which should be taken care of. 

When comparing the first line extracted by ```getline(infile, line)``` with ```"[header]"```, the line extracted by c++ standard library is everything in the line before ```\n```, which means that the little char ```\r``` is included in the line. Therefore, when comparing the first line -- ```"[header]\r"``` with ```"[header]"```, these two strings are not the same, and the parser failed. This problem is fixed by a simple approach: comparing both with ```"[header]"``` and ```"[header]\r"```